### PR TITLE
Add default modelsSource; remove Tailwind purge.enabled property

### DIFF
--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -34,3 +34,7 @@ contentModels:
     singleInstance: false
     urlPath: '/blog/category/{slug}'
     newFilePath: 'blog/category/{slug}.md'
+modelsSource:
+  type: files
+  modelDirs:
+    - .stackbit/models

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,6 @@ const themeStyle = require('./content/data/style.json');
 module.exports = {
     mode: 'jit',
     purge: {
-        enabled: false,
         content: [
             './src/**/*.{js,ts,jsx,tsx}',
             './content/**/*'


### PR DESCRIPTION
Two small improvements which were found when trying out custom package support:

1. Adding the default of `modelsSource` to `stackbit.yaml` makes it clearer where models are loaded from by default, and makes it easier to add more sources (as now you only need to add a line, rather than create this property)

2. As we've found, since Tailwind is in [JIT mode](https://tailwindcss.com/docs/just-in-time-mode), then `purge.enabled` being set to `false` in `tailwind.config.js` has no effect: the `purge.content` directories are ALWAYS used to define which styles are generated (and extra directories should be added when using components from other packages).
To prevent any confusion, we're removing the `enabled` property.